### PR TITLE
Ported BandwidthMonitor utility to.Net Core 3.1

### DIFF
--- a/BandWidthMonitor/App.config
+++ b/BandWidthMonitor/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
-</configuration>

--- a/BandWidthMonitor/BandwidthLogger.cs
+++ b/BandWidthMonitor/BandwidthLogger.cs
@@ -15,8 +15,8 @@ namespace BandwidthMonitor
         public BandwidthLogger(TimeSpan logFrequency)
         {
             if (logFrequency <= TimeSpan.Zero)
-            { 
-                throw new ArgumentOutOfRangeException("logFrequency"); 
+            {
+                throw new ArgumentOutOfRangeException("logFrequency");
             }
 
             _logFrequency = logFrequency;
@@ -31,7 +31,7 @@ namespace BandwidthMonitor
             {
                 const long bitsPerByte = 8;
                 const double oneMeg = 1024 * 1024;
-                
+
 
                 while (!_disposed)
                 {
@@ -40,13 +40,13 @@ namespace BandwidthMonitor
                     long bytesRead;
                     long bytesWrite;
                     GetNetworkUsage(out bytesRead, out bytesWrite);
-                    
+
                     DateTimeOffset currentTime = DateTimeOffset.UtcNow;
                     TimeSpan elapsed = currentTime - _previousComputeTime;
-                    
+
                     long readDelta = (bytesRead - _previousReadBytes);
                     long writeDelta = (bytesWrite - _previousWriteBytes);
-                    
+
                     _previousReadBytes = bytesRead;
                     _previousWriteBytes = bytesWrite;
                     _previousComputeTime = currentTime;
@@ -57,7 +57,7 @@ namespace BandwidthMonitor
                     LogUsage(mbitsReadPerSecond, mbitsWritePerSecond);
                 }
             }
-            catch(Exception)
+            catch (Exception)
             {
 
             }
@@ -88,7 +88,7 @@ namespace BandwidthMonitor
                     bytesWrite += nicbytesWrite;
                 }
             }
-            catch(Exception)
+            catch (Exception)
             {
 
             }

--- a/BandWidthMonitor/BandwidthMonitor.csproj
+++ b/BandWidthMonitor/BandwidthMonitor.csproj
@@ -8,7 +8,7 @@
 		For windows values for runtime identifiers are win10-x64, win10-x86, win81-x64 etc.
 		For Linux identifer values are linux-x64, linux-musl-x64, linux-arm, rhel-x64 etc.
 		More about identifiers, refer the official microsoft docs at https://docs.microsoft.com/en-us/dotnet/core/rid-catalog-->
-		<RuntimeIdentifier>linux-x64</RuntimeIdentifier>				
+		<RuntimeIdentifier>win10-x64</RuntimeIdentifier>				
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/BandWidthMonitor/BandwidthMonitor.csproj
+++ b/BandWidthMonitor/BandwidthMonitor.csproj
@@ -4,9 +4,11 @@
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<PublishSingleFile>true</PublishSingleFile>
 		<PublishTrimmed>true</PublishTrimmed>
-		<RuntimeIdentifier>linux-x64</RuntimeIdentifier>
-		<PublishSingleFile>true</PublishSingleFile>
-		<PublishTrimmed>true</PublishTrimmed>
+		<!--Change the runtime identifier according to target system
+		For windows values for runtime identifiers are win10-x64, win10-x86, win81-x64 etc.
+		For Linux identifer values are linux-x64, linux-musl-x64, linux-arm, rhel-x64 etc.
+		More about identifiers, refer the official microsoft docs at https://docs.microsoft.com/en-us/dotnet/core/rid-catalog-->
+		<RuntimeIdentifier>linux-x64</RuntimeIdentifier>				
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/BandWidthMonitor/BandwidthMonitor.csproj
+++ b/BandWidthMonitor/BandwidthMonitor.csproj
@@ -1,59 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{704D6A6C-711C-4332-9248-5F7009C1E071}</ProjectGuid>
-    <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BandwidthMonitor</RootNamespace>
-    <AssemblyName>BandwidthMonitor</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="BandwidthLogger.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<PublishSingleFile>true</PublishSingleFile>
+		<PublishTrimmed>true</PublishTrimmed>
+		<RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+		<PublishSingleFile>true</PublishSingleFile>
+		<PublishTrimmed>true</PublishTrimmed>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+	</ItemGroup>
+	<PropertyGroup>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+
 </Project>

--- a/BandWidthMonitor/Program.cs
+++ b/BandWidthMonitor/Program.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using BandwidthMonitor;
+using System;
 
-namespace BandwidthMonitor
+namespace BandWidthMonitor
 {
     class Program
     {
@@ -11,6 +12,6 @@ namespace BandwidthMonitor
                 Console.WriteLine("Press Enter to close application");
                 Console.ReadLine();
             }
-        }        
+        }
     }
 }

--- a/BandWidthMonitor/Properties/AssemblyInfo.cs
+++ b/BandWidthMonitor/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/ThreadPoolMonitor/App.config
+++ b/ThreadPoolMonitor/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
-</configuration>

--- a/ThreadPoolMonitor/PerfCounterHelper.cs
+++ b/ThreadPoolMonitor/PerfCounterHelper.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace ThreadPoolMonitor
 {
@@ -18,7 +16,7 @@ namespace ThreadPoolMonitor
             float systemCPU;
             if (PerfCounterHelper.TryGetSystemCPU(out systemCPU))
             {
-                cpu = Math.Round(systemCPU, 2) + "%"; 
+                cpu = Math.Round(systemCPU, 2) + "%";
             }
             return cpu;
         }

--- a/ThreadPoolMonitor/Program.cs
+++ b/ThreadPoolMonitor/Program.cs
@@ -13,6 +13,6 @@ namespace ThreadPoolMonitor
                 Console.WriteLine("Press Enter to close application");
                 Console.ReadLine();
             }
-        }        
+        }
     }
 }

--- a/ThreadPoolMonitor/Properties/AssemblyInfo.cs
+++ b/ThreadPoolMonitor/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/ThreadPoolMonitor/ThreadPoolLogger.cs
+++ b/ThreadPoolMonitor/ThreadPoolLogger.cs
@@ -4,102 +4,102 @@ using System.Threading.Tasks;
 
 namespace ThreadPoolMonitor
 {
-    class ThreadPoolLogger : IDisposable
-    {
-        private TimeSpan _logFrequency;
-        private bool _disposed;
+	class ThreadPoolLogger : IDisposable
+	{
+		private TimeSpan _logFrequency;
+		private bool _disposed;
 
-        public ThreadPoolLogger(TimeSpan logFrequency)
-        {
-            if (logFrequency <= TimeSpan.Zero)
-            { 
-                throw new ArgumentOutOfRangeException("logFrequency"); 
-            }
+		public ThreadPoolLogger(TimeSpan logFrequency)
+		{
+			if (logFrequency <= TimeSpan.Zero)
+			{
+				throw new ArgumentOutOfRangeException("logFrequency");
+			}
 
-            _logFrequency = logFrequency;                        
-            StartLogging();
-        }
+			_logFrequency = logFrequency;
+			StartLogging();
+		}
 
-        private async void StartLogging()
-        {
-            try
-            {
-                while (!_disposed)
-                {
-                    await Task.Delay(_logFrequency);
+		private async void StartLogging()
+		{
+			try
+			{
+				while (!_disposed)
+				{
+					await Task.Delay(_logFrequency);
 
-                    var stats = GetThreadPoolStats();
+					var stats = GetThreadPoolStats();
 
-                    LogUsage(stats);
-                }
-            }
-            catch(Exception)
-            {
+					LogUsage(stats);
+				}
+			}
+			catch (Exception)
+			{
 
-            }
-        }
+			}
+		}
 
-        protected virtual void LogUsage(ThreadPoolUsageStats stats)
-        {
-            string message = string.Format("[{0}] IOCP:(Busy={1},Min={2},Max={3}), WORKER:(Busy={4},Min={5},Max={6}), Local CPU: {7}", 
-                DateTimeOffset.UtcNow.ToString("u"),
-                stats.BusyIoThreads, stats.MinIoThreads, stats.MaxIoThreads,
-                stats.BusyWorkerThreads, stats.MinWorkerThreads, stats.MaxWorkerThreads,
-                PerfCounterHelper.GetSystemCPU()
-                );
-            
-            Console.WriteLine(message);
-        }
+		protected virtual void LogUsage(ThreadPoolUsageStats stats)
+		{
+			string message = string.Format("[{0}] IOCP:(Busy={1},Min={2},Max={3}), WORKER:(Busy={4},Min={5},Max={6}), Local CPU: {7}",
+				DateTimeOffset.UtcNow.ToString("u"),
+				stats.BusyIoThreads, stats.MinIoThreads, stats.MaxIoThreads,
+				stats.BusyWorkerThreads, stats.MinWorkerThreads, stats.MaxWorkerThreads,
+				PerfCounterHelper.GetSystemCPU()
+				);
 
-        /// <summary>
-        /// Returns the current thread pool usage statistics for the CURRENT AppDomain/Process
-        /// </summary>
-        public static ThreadPoolUsageStats GetThreadPoolStats()
-        {
-            //BusyThreads =  TP.GetMaxThreads() –TP.GetAVailable();
-            //If BusyThreads >= TP.GetMinThreads(), then threadpool growth throttling is possible.
+			Console.WriteLine(message);
+		}
 
-            int maxIoThreads, maxWorkerThreads;
-            ThreadPool.GetMaxThreads(out maxWorkerThreads, out maxIoThreads);
+		/// <summary>
+		/// Returns the current thread pool usage statistics for the CURRENT AppDomain/Process
+		/// </summary>
+		public static ThreadPoolUsageStats GetThreadPoolStats()
+		{
+			//BusyThreads =  TP.GetMaxThreads() –TP.GetAVailable();
+			//If BusyThreads >= TP.GetMinThreads(), then threadpool growth throttling is possible.
 
-            int freeIoThreads, freeWorkerThreads;
-            ThreadPool.GetAvailableThreads(out freeWorkerThreads, out freeIoThreads);
+			int maxIoThreads, maxWorkerThreads;
+			ThreadPool.GetMaxThreads(out maxWorkerThreads, out maxIoThreads);
 
-            int minIoThreads, minWorkerThreads;
-            ThreadPool.GetMinThreads(out minWorkerThreads, out minIoThreads);
+			int freeIoThreads, freeWorkerThreads;
+			ThreadPool.GetAvailableThreads(out freeWorkerThreads, out freeIoThreads);
 
-            int busyIoThreads = maxIoThreads - freeIoThreads;
-            int busyWorkerThreads = maxWorkerThreads - freeWorkerThreads;
+			int minIoThreads, minWorkerThreads;
+			ThreadPool.GetMinThreads(out minWorkerThreads, out minIoThreads);
 
-            return new ThreadPoolUsageStats
-            {
-                BusyIoThreads = busyIoThreads,
-                MinIoThreads = minIoThreads,
-                MaxIoThreads = maxIoThreads,
-                BusyWorkerThreads = busyWorkerThreads,
-                MinWorkerThreads = minWorkerThreads,
-                MaxWorkerThreads = maxWorkerThreads,
-            };
-        }
+			int busyIoThreads = maxIoThreads - freeIoThreads;
+			int busyWorkerThreads = maxWorkerThreads - freeWorkerThreads;
 
-        public void Dispose()
-        {
-            _disposed = true;
-        }
-    }
+			return new ThreadPoolUsageStats
+			{
+				BusyIoThreads = busyIoThreads,
+				MinIoThreads = minIoThreads,
+				MaxIoThreads = maxIoThreads,
+				BusyWorkerThreads = busyWorkerThreads,
+				MinWorkerThreads = minWorkerThreads,
+				MaxWorkerThreads = maxWorkerThreads,
+			};
+		}
 
-    public struct ThreadPoolUsageStats
-    {
-        public int BusyIoThreads { get; set; }
+		public void Dispose()
+		{
+			_disposed = true;
+		}
+	}
 
-        public int MinIoThreads { get; set; }
+	public struct ThreadPoolUsageStats
+	{
+		public int BusyIoThreads { get; set; }
 
-        public int MaxIoThreads { get; set; }
+		public int MinIoThreads { get; set; }
 
-        public int BusyWorkerThreads { get; set; }
+		public int MaxIoThreads { get; set; }
 
-        public int MinWorkerThreads { get; set; }
+		public int BusyWorkerThreads { get; set; }
 
-        public int MaxWorkerThreads { get; set; }
-    }
+		public int MinWorkerThreads { get; set; }
+
+		public int MaxWorkerThreads { get; set; }
+	}
 }

--- a/ThreadPoolMonitor/ThreadPoolMonitor.csproj
+++ b/ThreadPoolMonitor/ThreadPoolMonitor.csproj
@@ -1,60 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{704D6A6C-711C-4332-9248-5F7009C1E071}</ProjectGuid>
-    <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ThreadPoolMonitor</RootNamespace>
-    <AssemblyName>ThreadPoolMonitor</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="PerfCounterHelper.cs" />
-    <Compile Include="ThreadPoolLogger.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<PublishSingleFile>true</PublishSingleFile>
+		<PublishTrimmed>true</PublishTrimmed>
+		<!--Change the runtime identifier according to target system
+		For windows values for runtime identifiers are win10-x64, win10-x86, win81-x64 etc.
+		For Linux identifer values are linux-x64, linux-musl-x64, linux-arm, rhel-x64 etc.
+		More about identifiers, refer the official microsoft docs at https://docs.microsoft.com/en-us/dotnet/core/rid-catalog-->
+		<RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+	</PropertyGroup>
+	<PropertyGroup>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+	<ItemGroup>
+	  <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
I have migrated this utility to .Net Core 3.1. Now you can run it on linux. I found this utility quite useful for checking bandwidth usage on Redis server. Deployment of this utility is super easy since it is self contained single exe. There is no need of .Net Core installation on the target machine. Simply xcopy the file and give the appropriate permission to run it on linux server. Bandwidth usage on Redis server can be easily monitored.